### PR TITLE
Fix Meshcentral Service Values

### DIFF
--- a/charts/meshcentral/Chart.yaml
+++ b/charts/meshcentral/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: meshcentral
 description: A Helm chart for deploying MeshCentral
-version: 0.2.0
+version: 0.2.1
 appVersion: "1.1.43"

--- a/charts/meshcentral/values.yaml
+++ b/charts/meshcentral/values.yaml
@@ -106,6 +106,10 @@ meshcentral:
       enabled: false
       sponsor: false
 
+service:
+  type: ClusterIP
+  port: 443
+
 ingress:
   enabled: false
   ingressClassName: ""


### PR DESCRIPTION
The Meshcentral service type was nested under the `meshcentral` key but should've been at the root level.