### PR TITLE
Adding ability to set serviceAccount.name in cloudflare-tunnel chart

### DIFF
--- a/charts/cloudflare-tunnel/Chart.yaml
+++ b/charts/cloudflare-tunnel/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0
+version: 0.11.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloudflare-tunnel/templates/deployment.yaml
+++ b/charts/cloudflare-tunnel/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "cloudflare-tunnel.fullname" . }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default (include "cloudflare-tunnel.fullname" .) }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/cloudflare-tunnel/templates/serviceaccount.yaml
+++ b/charts/cloudflare-tunnel/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "cloudflare-tunnel.fullname" . }}
+  name: {{ .Values.serviceAccount.name | default (include "cloudflare-tunnel.fullname" .) }}
   labels:
     {{- include "cloudflare-tunnel.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION
This changes adds functionality to the serviceAccount.name value field. 

Previously, both serviceaccount.yaml and deployment.yaml did not take it into consideration, and just used cloudflare-tunnel.fullname.