### PR TITLE
adding support to mount a volume for cloudflare tunnel credentials

### DIFF
--- a/charts/cloudflare-tunnel/Chart.yaml
+++ b/charts/cloudflare-tunnel/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0
+version: 0.12.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloudflare-tunnel/README.md
+++ b/charts/cloudflare-tunnel/README.md
@@ -26,6 +26,7 @@ The following table lists the configurable parameters of the Cloudflare Tunnel c
 | `cloudflare.tunnelId`             | The ID of the above tunnel                       | `""`                           |
 | `cloudflare.secret`               | The secret for the tunnel                        | `""`                           |
 | `cloudflare.secretName`           | The secret name for the credentials              | `null`                         |
+| `cloudflare.credentialsVolume`    | Override the creds volume source entirely        | `null`                         |
 | `cloudflare.enableWarp`           | Enable WARP routing for TCP                      | `false`                        |
 | `cloudflare.ingress`              | Ingress rules for the tunnel                     | `[]`                           |
 | `image.repository`                | Image repository                                 | `cloudflare/cloudflared`       |
@@ -54,6 +55,13 @@ Alternatively, a YAML file that specifies the values for the parameters can be p
 ```sh
 helm install my-release wrsys/cloudflare-tunnel -f values.yaml
 ```
+
+## Credentials
+
+The chart supports inline secret creation, an external Secret reference, and a fully custom volume
+source (CSI drivers, projected volumes, sidecar injectors, and more).
+
+See [docs/credentials.md](./docs/credentials.md) for all credential modes and examples.
 
 ## Uninstallation
 

--- a/charts/cloudflare-tunnel/docs/credentials.md
+++ b/charts/cloudflare-tunnel/docs/credentials.md
@@ -1,0 +1,96 @@
+# Cloudflare Tunnel — Credentials
+
+The chart supports three ways to provide tunnel credentials, evaluated in order of precedence.
+cloudflared expects a `credentials.json` file at `/etc/cloudflared/creds/credentials.json`.
+
+## 1. Inline values (chart creates the Secret)
+
+Supply `cloudflare.account`, `cloudflare.tunnelId`, and `cloudflare.secret`. The chart renders a
+`credentials.json` Secret automatically. No other configuration is needed.
+
+```yaml
+cloudflare:
+  account: "your-account-tag"
+  tunnelId: "your-tunnel-id"
+  secret: "your-tunnel-secret"
+```
+
+## 2. Pre-existing Secret (`cloudflare.secretName`)
+
+Point the chart at a Secret you manage externally (e.g. via External Secrets Operator, Helm secret
+management, or manual creation). The Secret must contain a key named `credentials.json`.
+
+```yaml
+cloudflare:
+  secretName: my-cloudflare-secret
+```
+
+## 3. Custom volume source (`cloudflare.credentialsVolume`)
+
+Override the entire `creds` volume source. Use this when credentials are provided by a CSI driver,
+sidecar injector, or any other mechanism. The value is passed through verbatim as the Kubernetes
+volume source. `secretName` is ignored and no Secret is created from inline values when this is set.
+
+Any valid Kubernetes volume source type can be used. See the [Kubernetes volumes documentation](https://kubernetes.io/docs/concepts/storage/volumes/).
+
+**Rollout on credential rotation:** when `credentialsVolume` is set, the chart does not include a
+`checksum/secret` pod annotation, so credential changes will not automatically restart the pod.
+
+### Example A — Secrets Store CSI driver
+
+Works with Azure Key Vault, AWS Secrets Manager, GCP Secret Manager, and HashiCorp Vault via the
+[Secrets Store CSI Driver](https://secrets-store-csi-driver.sigs.k8s.io/). Requires a
+`SecretProviderClass` resource to be deployed separately. The SPC must expose the credential
+under the key `credentials.json`.
+
+```yaml
+cloudflare:
+  credentialsVolume:
+    csi:
+      driver: secrets-store.csi.k8s.io
+      readOnly: true
+      volumeAttributes:
+        secretProviderClass: cloudflare-tunnel-spc
+```
+
+### Example B — hostPath (local file)
+
+Use a `hostPath` volume to mount a credentials file that already exists on the node's filesystem.
+This is useful for local development (e.g. a file created by `cloudflared tunnel login`) or
+single-node environments where you control the node directly.
+
+`cloudflared tunnel login` stores credentials as `~/.cloudflared/<tunnel-id>.json`. The chart
+expects the file to be named `credentials.json` inside the mounted directory, so copy it first:
+
+```sh
+mkdir -p /etc/cloudflared/creds
+cp ~/.cloudflared/*.json /etc/cloudflared/creds/credentials.json
+```
+
+> If you have multiple tunnel credential files in `~/.cloudflared/`, specify the file explicitly
+> rather than using the glob.
+
+```yaml
+cloudflare:
+  credentialsVolume:
+    hostPath:
+      path: /etc/cloudflared/creds
+      type: Directory
+```
+
+> **Warning:** `hostPath` volumes are node-scoped. Not recommended for production or multi-node clusters.
+
+> **Local dev — file permissions:** the pod runs as UID `65532` by default. If the credential files
+> are owned by your local user, the pod will fail to read them. Either transfer ownership of the
+> files to UID `65532` on the node:
+>
+> ```sh
+> chown -R 65532 /etc/cloudflared/creds
+> ```
+>
+> Or override `runAsUser` at install time to match your local UID instead:
+>
+> ```sh
+> helm upgrade --install my-release ./charts/cloudflare-tunnel \
+>   --set podSecurityContext.runAsUser=$(id -u)
+> ```

--- a/charts/cloudflare-tunnel/templates/deployment.yaml
+++ b/charts/cloudflare-tunnel/templates/deployment.yaml
@@ -16,7 +16,9 @@ spec:
       annotations:
         # These are here so the deployment rolls when the config or secret change.
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if not .Values.cloudflare.credentialsVolume }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -69,8 +71,12 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: creds
+          {{- if .Values.cloudflare.credentialsVolume }}
+          {{- toYaml .Values.cloudflare.credentialsVolume | nindent 10 }}
+          {{- else }}
           secret:
             secretName: {{ .Values.cloudflare.secretName | default (include "cloudflare-tunnel.fullname" .) }}
+          {{- end }}
         - name: config
           configMap:
             name: {{ include "cloudflare-tunnel.fullname" . }}

--- a/charts/cloudflare-tunnel/templates/secret.yaml
+++ b/charts/cloudflare-tunnel/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (and .Values.cloudflare.account .Values.cloudflare.tunnelId .Values.cloudflare.secret) (not .Values.cloudflare.secretName) }}
+{{- if and (and .Values.cloudflare.account .Values.cloudflare.tunnelId .Values.cloudflare.secret) (not .Values.cloudflare.secretName) (not .Values.cloudflare.credentialsVolume) }}
 # This credentials secret allows cloudflared to authenticate itself
 # to the Cloudflare infrastructure.
 apiVersion: v1

--- a/charts/cloudflare-tunnel/values.yaml
+++ b/charts/cloudflare-tunnel/values.yaml
@@ -12,6 +12,9 @@ cloudflare:
   secret: ""
   # If defined, no secret is created for the credentials, and instead, the secret referenced is used
   secretName: null
+  # If defined, credentialsVolume overrides the creds volume. Takes precedence over secretName and inline values
+  # See docs/credentials.md for examples.
+  credentialsVolume: null
   # Specifies the protocol used to establish a connection between cloudflared and the Cloudflare global network. Available values are auto, http2, h2mux, and quic. (default: auto)
   # https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide/local/local-management/arguments/
   protocol: ""


### PR DESCRIPTION
This PR adds support to the cloudflare-tunnel helm chart to mount a different volume than a secret. It is similar in functionality with `secretName`, in that it requires a kubernetes resource to be created outside of the helm chart.

There is documentation added in the new docs/ folder at docs/credentials.md for what I believe are common use cases: csi drivers and hostPath for local development.

Disclaimer: most of this change was written by AI, reviewed by me, reviewed by AI, changed and edited by me, reviewed again by me, but this is something I could use at my company to make provisioning tunnels easier.